### PR TITLE
Update color scheme and merge skills

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import Experience from './components/Experience';
 import Education from './components/Education';
 import Portfolio from './components/Portfolio';
 import Gallery from './components/Gallery';
-import Skills from './components/Skills';
 import Contact from './components/Contact';
 import Footer from './components/Footer';
 
@@ -25,7 +24,7 @@ function App() {
 
   useEffect(() => {
     const handleScroll = () => {
-      const sections = ['home', 'experience', 'education', 'portfolio', 'gallery', 'skills', 'contact'];
+      const sections = ['home', 'experience', 'education', 'portfolio', 'gallery', 'contact'];
       const scrollPosition = window.scrollY + 100;
 
       for (const section of sections) {
@@ -96,7 +95,6 @@ function App() {
           <Education />
           <Portfolio />
           <Gallery />
-          <Skills />
           <Contact />
         </main>
 

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -118,7 +118,7 @@ const Contact: React.FC = () => {
           className="text-center mb-16"
         >
           <h2 className="text-4xl sm:text-5xl font-bold mb-4">
-            <span className="bg-gradient-to-r from-purple-400 to-blue-400 bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent">
               Trabajemos Juntos
             </span>
           </h2>
@@ -154,14 +154,14 @@ const Contact: React.FC = () => {
                   initial={{ opacity: 0, y: 20 }}
                   animate={inView ? { opacity: 1, y: 0 } : {}}
                   transition={{ duration: 0.6, delay: 0.3 + index * 0.1 }}
-                  className="group flex items-center gap-4 p-4 bg-gradient-to-br from-gray-900/50 to-gray-800/50 border border-gray-700/50 rounded-xl backdrop-blur-sm hover:border-purple-500/30 transition-all duration-300"
+                  className="group flex items-center gap-4 p-4 bg-gradient-to-br from-gray-900/50 to-gray-800/50 border border-gray-700/50 rounded-xl backdrop-blur-sm hover:border-[#0072C6]/30 transition-all duration-300"
                 >
-                  <div className="p-3 bg-gradient-to-r from-purple-500/20 to-blue-500/20 rounded-lg group-hover:from-purple-500/30 group-hover:to-blue-500/30 transition-colors">
-                    <contact.icon className="text-purple-400 group-hover:text-white transition-colors" size={24} />
+                  <div className="p-3 bg-gradient-to-r from-[#F2A900]/20 to-[#0072C6]/20 rounded-lg group-hover:from-[#F2A900]/30 group-hover:to-[#0072C6]/30 transition-colors">
+                    <contact.icon className="text-[#F2A900] group-hover:text-white transition-colors" size={24} />
                   </div>
                   <div>
                     <div className="text-gray-400 text-sm">{contact.label}</div>
-                    <div className="text-white font-medium group-hover:text-purple-400 transition-colors">
+                    <div className="text-white font-medium group-hover:text-[#F2A900] transition-colors">
                       {contact.value}
                     </div>
                   </div>

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -25,7 +25,7 @@ const Education: React.FC = () => {
           className="text-center mb-16"
         >
           <h2 className="text-4xl sm:text-5xl font-bold mb-4">
-            <span className="bg-gradient-to-r from-purple-400 to-red-400 bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent">
               Educación y Certificaciones
             </span>
           </h2>
@@ -37,7 +37,7 @@ const Education: React.FC = () => {
         {/* Timeline Layout */}
         <div className="relative">
           {/* Timeline Line */}
-          <div className="absolute left-4 md:left-1/2 top-0 bottom-0 w-0.5 bg-gradient-to-b from-purple-500 to-red-500 transform md:-translate-x-0.5"></div>
+          <div className="absolute left-4 md:left-1/2 top-0 bottom-0 w-0.5 bg-gradient-to-b from-[#F2A900] to-[#0072C6] transform md:-translate-x-0.5"></div>
 
           {/* Items de educacion*/}
           <div className="space-y-12">
@@ -52,7 +52,7 @@ const Education: React.FC = () => {
                 } flex-col md:flex-row`}
               >
                 {/* Nodo Timeline  */}
-                <div className="absolute left-4 md:left-1/2 w-4 h-4 bg-gradient-to-r from-purple-500 to-red-500 rounded-full transform md:-translate-x-2 z-10 shadow-lg">
+                <div className="absolute left-4 md:left-1/2 w-4 h-4 bg-gradient-to-r from-[#F2A900] to-[#0072C6] rounded-full transform md:-translate-x-2 z-10 shadow-lg">
                   <div className="absolute inset-1 bg-gray-900 rounded-full"></div>
                 </div>
 
@@ -66,20 +66,20 @@ const Education: React.FC = () => {
                         window.open(edu.certificateUrl, '_blank');
                       }
                     }}
-                    className="group bg-gradient-to-br from-gray-900/50 to-gray-800/50 border border-gray-700/50 rounded-2xl p-6 backdrop-blur-sm hover:border-purple-500/30 transition-all duration-300"
+                    className="group bg-gradient-to-br from-gray-900/50 to-gray-800/50 border border-gray-700/50 rounded-2xl p-6 backdrop-blur-sm hover:border-[#0072C6]/30 transition-all duration-300"
                     style={{ cursor: edu.certificateUrl ? 'pointer' : 'default' }}
                   >
                     {/* Status Badge */}
                     <div className="flex items-center justify-between mb-4">
                       <div className="flex items-center gap-2">
                         {edu.status === 'Current Student' ? (
-                          <GraduationCap className="text-purple-400" size={20} />
+                          <GraduationCap className="text-[#0072C6]" size={20} />
                         ) : (
                           <Award className="text-green-400" size={20} />
                         )}
                         <span className={`text-xs font-medium px-2 py-1 rounded-full ${
                           edu.status === 'Current Student' 
-                            ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
+                            ? 'bg-[#0072C6]/20 text-[#0072C6] border border-[#0072C6]/30'
                             : 'bg-green-500/20 text-green-400 border border-green-500/30'
                         }`}>
                           {edu.status}
@@ -92,10 +92,10 @@ const Education: React.FC = () => {
                     </div>
 
                     {/* Degree & Institution */}
-                    <h3 className="text-xl font-bold text-white mb-2 group-hover:text-purple-400 transition-colors">
+                    <h3 className="text-xl font-bold text-white mb-2 group-hover:text-[#F2A900] transition-colors">
                       {edu.degree}
                     </h3>
-                    <p className="text-purple-400 font-medium mb-4">{edu.institution}</p>
+                    <p className="text-[#0072C6] font-medium mb-4">{edu.institution}</p>
 
                     {/* GPA */}
                     {edu.gpa && (
@@ -123,7 +123,7 @@ const Education: React.FC = () => {
                     )}
 
                     {/* Hover Effect */}
-                    <div className="absolute inset-0 bg-gradient-to-r from-purple-500/5 to-red-500/5 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                    <div className="absolute inset-0 bg-gradient-to-r from-[#F2A900]/5 to-[#0072C6]/5 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                   </div>
                 </div>
               </motion.div>
@@ -135,7 +135,7 @@ const Education: React.FC = () => {
           <div className="text-center mt-8">
             <button
               onClick={() => setShowAll(!showAll)}
-              className="px-6 py-2 bg-gradient-to-r from-purple-600 to-red-600 text-white rounded-lg font-medium hover:from-purple-700 hover:to-red-700 transition-all duration-300"
+              className="px-6 py-2 bg-gradient-to-r from-[#F2A900] to-[#0072C6] text-white rounded-lg font-medium hover:from-[#d99900] hover:to-[#0060a3] transition-all duration-300"
             >
               {showAll ? 'Mostrar menos' : 'Mostrar línea de tiempo completa'}
             </button>
@@ -164,9 +164,9 @@ const Education: React.FC = () => {
             ].map((cert, index) => (
               <div
                 key={index}
-                className="flex items-center gap-3 p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 hover:border-purple-500/30 transition-colors"
+                className="flex items-center gap-3 p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 hover:border-[#0072C6]/30 transition-colors"
               >
-                <Award className="text-purple-400 flex-shrink-0" size={16} />
+                <Award className="text-[#0072C6] flex-shrink-0" size={16} />
                 <span className="text-gray-300 text-sm">{cert}</span>
               </div>
             ))}

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -2,13 +2,25 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { MapPin, Calendar, ExternalLink } from 'lucide-react';
-import { experiences } from '../data/portfolio';
+import * as Icons from 'lucide-react';
+import { experiences, skills } from '../data/portfolio';
 
 const Experience: React.FC = () => {
   const [ref, inView] = useInView({
     threshold: 0.1,
     triggerOnce: true
   });
+
+  const categories = [...new Set(skills.map(skill => skill.category))];
+
+  const getSkillsByCategory = (category: string) => {
+    return skills.filter(skill => skill.category === category);
+  };
+
+  const getIconComponent = (iconName: string) => {
+    const IconComponent = (Icons as any)[iconName];
+    return IconComponent || Icons.Code;
+  };
 
   return (
     <section id="experience" className="py-20 px-4 sm:px-6 lg:px-8">
@@ -21,8 +33,8 @@ const Experience: React.FC = () => {
           className="text-center mb-16"
         >
           <h2 className="text-4xl sm:text-5xl font-bold mb-4">
-            <span className="bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
-              Experiencia Profesional
+            <span className="bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent">
+              Experiencia y Habilidades
             </span>
           </h2>
           <p className="text-gray-400 text-lg max-w-2xl mx-auto">
@@ -40,7 +52,7 @@ const Experience: React.FC = () => {
               transition={{ duration: 0.6, delay: index * 0.1 }}
               className={`group relative bg-gradient-to-br from-gray-900/50 to-gray-800/50 border border-gray-700/50 rounded-2xl p-6 ${
                 exp.current ? 'pt-10' : ''
-              } backdrop-blur-sm hover:border-blue-500/30 transition-all duration-300 ${
+              } backdrop-blur-sm hover:border-[#0072C6]/30 transition-all duration-300 ${
                 index === 0 ? 'lg:col-span-2' : ''
               }`}
             >
@@ -56,10 +68,10 @@ const Experience: React.FC = () => {
 
               {/* Company & Position */}
               <div className="mb-4">
-                <h3 className="text-xl font-bold text-white mb-2 group-hover:text-blue-400 transition-colors">
+                <h3 className="text-xl font-bold text-white mb-2 group-hover:text-[#F2A900] transition-colors">
                   {exp.title}
                 </h3>
-                <p className="text-purple-400 font-medium mb-3">{exp.company}</p>
+                <p className="text-[#0072C6] font-medium mb-3">{exp.company}</p>
                 
                 <div className="flex flex-wrap gap-4 text-sm text-gray-400">
                   <div className="flex items-center gap-1">
@@ -79,7 +91,7 @@ const Experience: React.FC = () => {
                   {exp.techStack.map((tech, techIndex) => (
                     <span
                       key={techIndex}
-                      className="px-3 py-1 text-xs font-medium bg-blue-500/10 text-blue-400 border border-blue-500/20 rounded-full"
+                      className="px-3 py-1 text-xs font-medium bg-[#0072C6]/10 text-[#0072C6] border border-[#0072C6]/20 rounded-full"
                     >
                       {tech}
                     </span>
@@ -91,14 +103,14 @@ const Experience: React.FC = () => {
               <div className="space-y-3">
                 {exp.responsibilities.map((responsibility, respIndex) => (
                   <div key={respIndex} className="flex items-start gap-3">
-                    <div className="w-1.5 h-1.5 bg-gradient-to-r from-blue-400 to-purple-400 rounded-full mt-2 flex-shrink-0"></div>
+                    <div className="w-1.5 h-1.5 bg-gradient-to-r from-[#F2A900] to-[#0072C6] rounded-full mt-2 flex-shrink-0"></div>
                     <p className="text-gray-300 text-sm leading-relaxed">{responsibility}</p>
                   </div>
                 ))}
               </div>
 
               {/* Hover Effect */}
-              <div className="absolute inset-0 bg-gradient-to-r from-blue-500/5 to-purple-500/5 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+              <div className="absolute inset-0 bg-gradient-to-r from-[#F2A900]/5 to-[#0072C6]/5 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
             </motion.div>
           ))}
         </div>
@@ -117,12 +129,97 @@ const Experience: React.FC = () => {
             { number: '15+', label: 'Tecnologías Dominadas' }
           ].map((stat, index) => (
             <div key={index} className="text-center">
-              <div className="text-2xl sm:text-3xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent mb-2">
+              <div className="text-2xl sm:text-3xl font-bold bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent mb-2">
                 {stat.number}
               </div>
               <div className="text-gray-400 text-sm">{stat.label}</div>
             </div>
           ))}
+        </motion.div>
+
+        {/* Skills */}
+        <div className="mt-20 space-y-8">
+          {categories.map((category, categoryIndex) => {
+            const categorySkills = getSkillsByCategory(category);
+
+            return (
+              <motion.div
+                key={category}
+                initial={{ opacity: 0, y: 30 }}
+                animate={inView ? { opacity: 1, y: 0 } : {}}
+                transition={{ duration: 0.6, delay: categoryIndex * 0.1 }}
+                className="relative"
+              >
+                <div className="mb-8">
+                  <h3 className="text-2xl font-bold text-white mb-2">{category}</h3>
+                  <div className="w-20 h-1 bg-gradient-to-r from-[#F2A900] to-[#0072C6] rounded-full"></div>
+                </div>
+
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2 place-items-center">
+                  {categorySkills.map((skill, skillIndex) => {
+                    const IconComponent = getIconComponent(skill.icon);
+
+                    return (
+                      <motion.div
+                        key={skill.name}
+                        initial={{ opacity: 0, scale: 0.8 }}
+                        animate={inView ? { opacity: 1, scale: 1 } : {}}
+                        transition={{
+                          duration: 0.4,
+                          delay: categoryIndex * 0.1 + skillIndex * 0.05
+                        }}
+                        className="skill-card group relative flex flex-col items-center justify-center gap-3 bg-gradient-to-br from-gray-900/50 to-gray-800/50 border border-gray-700/50 rounded-xl p-6 h-32 backdrop-blur-sm hover:border-[#0072C6]/30 transition-all duration-300"
+                      >
+                        <div className="p-3 bg-gradient-to-r from-[#F2A900]/20 to-[#0072C6]/20 rounded-lg">
+                          <IconComponent className="text-[#0072C6] group-hover:text-white transition-colors" size={28} />
+                        </div>
+
+                        <h4 className="text-white font-semibold text-sm text-center group-hover:text-[#F2A900] transition-colors">
+                          {skill.name}
+                        </h4>
+
+                        <div className="shine-effect absolute inset-0 rounded-xl pointer-events-none"></div>
+                      </motion.div>
+                    );
+                  })}
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6, delay: 0.8 }}
+          className="mt-16 text-center"
+        >
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
+            <div className="text-center">
+              <div className="text-3xl font-bold bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent mb-2">
+                20+
+              </div>
+              <div className="text-gray-400 text-sm">Tecnologías</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold bg-gradient-to-r from-[#0072C6] to-[#F2A900] bg-clip-text text-transparent mb-2">
+                5+
+              </div>
+              <div className="text-gray-400 text-sm">Años de Experiencia</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent mb-2">
+                6
+              </div>
+              <div className="text-gray-400 text-sm">Categorías de Habilidades</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold bg-gradient-to-r from-[#0072C6] to-[#F2A900] bg-clip-text text-transparent mb-2">
+                90%
+              </div>
+              <div className="text-gray-400 text-sm">Promedio de Dominio</div>
+            </div>
+          </div>
         </motion.div>
       </div>
     </section>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -39,7 +39,7 @@ const Footer: React.FC = () => {
               transition={{ duration: 0.6 }}
               className="mb-6"
             >
-              <h3 className="text-2xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent mb-3">
+              <h3 className="text-2xl font-bold bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent mb-3">
                 Sebastian Jaque
               </h3>
               <p className="text-gray-400 max-w-md">

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -17,7 +17,7 @@ const Gallery: React.FC = () => {
           className="text-center mb-16"
         >
           <h2 className="text-4xl sm:text-5xl font-bold mb-4">
-            <span className="bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent">
               Galería Multimedia
             </span>
           </h2>
@@ -54,7 +54,7 @@ const Gallery: React.FC = () => {
             href="https://github.com/sjaquer"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-lg font-medium hover:from-purple-700 hover:to-pink-700 transition-all duration-300"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-[#F2A900] to-[#0072C6] text-white rounded-lg font-medium hover:from-[#d99900] hover:to-[#0060a3] transition-all duration-300"
           >
             Ver portafolio completo
           </a>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,7 +16,6 @@ const Header: React.FC<HeaderProps> = ({ activeSection, setActiveSection }) => {
     { id: 'education', label: 'Educación' },
     { id: 'portfolio', label: 'Portafolio' },
     { id: 'gallery', label: 'Galería' },
-    { id: 'skills', label: 'Habilidades' },
     { id: 'contact', label: 'Contacto' }
   ];
 
@@ -38,9 +37,9 @@ const Header: React.FC<HeaderProps> = ({ activeSection, setActiveSection }) => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
-          <motion.div 
+          <motion.div
             whileHover={{ scale: 1.05 }}
-            className="text-xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent"
+            className="text-xl font-bold bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent"
           >
             SJ
           </motion.div>
@@ -52,8 +51,8 @@ const Header: React.FC<HeaderProps> = ({ activeSection, setActiveSection }) => {
                 key={section.id}
                 onClick={() => scrollToSection(section.id)}
                 className={`text-sm font-medium transition-colors duration-200 ${
-                  activeSection === section.id 
-                    ? 'text-blue-400' 
+                  activeSection === section.id
+                    ? 'text-[#F2A900]'
                     : 'text-gray-300 hover:text-white'
                 }`}
               >
@@ -88,8 +87,8 @@ const Header: React.FC<HeaderProps> = ({ activeSection, setActiveSection }) => {
                 key={section.id}
                 onClick={() => scrollToSection(section.id)}
                 className={`block w-full text-left py-2 px-4 text-sm font-medium transition-colors duration-200 ${
-                  activeSection === section.id 
-                    ? 'text-blue-400 bg-gray-800/50' 
+                  activeSection === section.id
+                    ? 'text-[#F2A900] bg-gray-800/50'
                     : 'text-gray-300 hover:text-white hover:bg-gray-800/30'
                 }`}
               >

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -77,11 +77,11 @@ const Hero: React.FC = () => {
               transition={{ delay: 0.4 }}
               className="text-xl sm:text-2xl lg:text-3xl font-medium text-gray-300 mb-6"
             >
-              <span className="bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
+              <span className="bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent">
                 Creative Business Designer
               </span>
               <span className="text-gray-400"> & </span>
-              <span className="bg-gradient-to-r from-purple-400 to-red-400 bg-clip-text text-transparent">
+              <span className="bg-gradient-to-r from-[#0072C6] to-[#F2A900] bg-clip-text text-transparent">
                 Solutions Developer
               </span>
             </motion.div>
@@ -108,7 +108,7 @@ const Hero: React.FC = () => {
               {specialties.map((specialty, index) => (
                 <div
                   key={index}
-                  className="flex items-center gap-2 p-3 bg-gray-800/50 rounded-lg border border-gray-700/50 hover:border-purple-500/30 transition-all duration-300"
+                  className="flex items-center gap-2 p-3 bg-gray-800/50 rounded-lg border border-gray-700/50 hover:border-[#0072C6]/30 transition-all duration-300"
                 >
                   <div className={`p-2 bg-gradient-to-r ${specialty.color} bg-opacity-20 rounded-lg`}>
                     <specialty.icon size={16} className={`bg-gradient-to-r ${specialty.color} bg-clip-text text-transparent`} />
@@ -144,7 +144,7 @@ const Hero: React.FC = () => {
             >
               <button
                 onClick={handleDownloadCV}
-                className="group flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg font-medium hover:from-blue-700 hover:to-purple-700 transition-all duration-300 transform hover:scale-105"
+                className="group flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-[#F2A900] to-[#0072C6] text-white rounded-lg font-medium hover:from-[#d99900] hover:to-[#0060a3] transition-all duration-300 transform hover:scale-105"
               >
                 <Download size={18} />
                 Descargar CV
@@ -192,11 +192,11 @@ const Hero: React.FC = () => {
           >
             <div className="relative">
               {/* Fondo Animado */}
-              <div className="absolute inset-0 bg-gradient-to-r from-blue-500/20 via-purple-500/20 to-red-500/20 rounded-full blur-2xl animate-pulse"></div>
+              <div className="absolute inset-0 bg-gradient-to-r from-[#F2A900]/20 via-[#0072C6]/20 to-[#F2A900]/20 rounded-full blur-2xl animate-pulse"></div>
               
               {/* Imagen de Perfil */}
               <div className="relative w-64 h-64 sm:w-80 sm:h-80 lg:w-96 lg:h-96">
-                <div className="w-full h-full rounded-full bg-gradient-to-br from-blue-500 via-purple-500 to-red-500 p-1">
+                <div className="w-full h-full rounded-full bg-gradient-to-br from-[#F2A900] via-[#0072C6] to-[#F2A900] p-1">
                   <div className="w-full h-full rounded-full bg-gray-900 flex items-center justify-center overflow-hidden">
                     <img
                       src={profileImg}
@@ -212,7 +212,7 @@ const Hero: React.FC = () => {
                 initial={{ opacity: 0, scale: 0 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ delay: 1.2, type: 'spring' }}
-                className="absolute -top-4 -right-4 p-3 bg-blue-500 rounded-full shadow-lg"
+                className="absolute -top-4 -right-4 p-3 bg-[#0072C6] rounded-full shadow-lg"
               >
                 <Briefcase size={20} className="text-white" />
               </motion.div>
@@ -221,7 +221,7 @@ const Hero: React.FC = () => {
                 initial={{ opacity: 0, scale: 0 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ delay: 1.4, type: 'spring' }}
-                className="absolute -bottom-4 -left-4 p-3 bg-purple-500 rounded-full shadow-lg"
+                className="absolute -bottom-4 -left-4 p-3 bg-[#F2A900] rounded-full shadow-lg"
               >
                 <Code size={20} className="text-white" />
               </motion.div>

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -46,7 +46,7 @@ const Portfolio: React.FC = () => {
           className="text-center mb-16"
         >
           <h2 className="text-4xl sm:text-5xl font-bold mb-4">
-            <span className="bg-gradient-to-r from-red-400 to-purple-400 bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent">
               Portafolio Destacado
             </span>
           </h2>
@@ -68,7 +68,7 @@ const Portfolio: React.FC = () => {
               onClick={() => setFilter(category.id)}
               className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all duration-300 ${
                 filter === category.id
-                  ? 'bg-gradient-to-r from-red-500 to-purple-500 text-white'
+                  ? 'bg-gradient-to-r from-[#F2A900] to-[#0072C6] text-white'
                   : 'bg-gray-800/50 text-gray-400 hover:text-white hover:bg-gray-700/50'
               }`}
             >
@@ -103,13 +103,13 @@ const Portfolio: React.FC = () => {
                   
                   {/* Category Badge */}
                   <div className="absolute top-4 left-4 flex items-center gap-2 px-3 py-1 bg-black/70 backdrop-blur-sm rounded-full">
-                    <CategoryIcon size={14} className="text-red-400" />
+                    <CategoryIcon size={14} className="text-[#F2A900]" />
                     <span className="text-xs text-white font-medium capitalize">{project.category}</span>
                   </div>
 
                   {/* Featured Badge */}
                   {project.featured && (
-                    <div className="absolute top-4 right-4 px-3 py-1 bg-gradient-to-r from-red-500 to-purple-500 text-white text-xs font-medium rounded-full">
+                    <div className="absolute top-4 right-4 px-3 py-1 bg-gradient-to-r from-[#F2A900] to-[#0072C6] text-white text-xs font-medium rounded-full">
                       Destacado
                     </div>
                   )}
@@ -124,7 +124,7 @@ const Portfolio: React.FC = () => {
                         href={project.liveUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="flex items-center gap-2 px-3 py-2 bg-red-600 text-white rounded-lg text-sm font-medium hover:bg-red-700 transition-colors"
+                        className="flex items-center gap-2 px-3 py-2 bg-[#F2A900] text-gray-900 rounded-lg text-sm font-medium hover:bg-[#d99900] transition-colors"
                       >
                         <ExternalLink size={14} />
                         Ver Demo
@@ -146,7 +146,7 @@ const Portfolio: React.FC = () => {
 
                 {/* Project Info */}
                 <div className="p-6">
-                  <h3 className="text-xl font-bold text-white mb-2 group-hover:text-red-400 transition-colors">
+                  <h3 className="text-xl font-bold text-white mb-2 group-hover:text-[#F2A900] transition-colors">
                     {project.title}
                   </h3>
                   <p className="text-gray-400 text-sm mb-4 line-clamp-2">
@@ -158,7 +158,7 @@ const Portfolio: React.FC = () => {
                     {project.techStack.map((tech, techIndex) => (
                       <span
                         key={techIndex}
-                        className="px-2 py-1 text-xs font-medium bg-red-500/10 text-red-400 border border-red-500/20 rounded-md"
+                        className="px-2 py-1 text-xs font-medium bg-[#0072C6]/10 text-[#0072C6] border border-[#0072C6]/20 rounded-md"
                       >
                         {tech}
                       </span>
@@ -167,7 +167,7 @@ const Portfolio: React.FC = () => {
                 </div>
 
                 {/* Hover Effect */}
-                <div className="absolute inset-0 bg-gradient-to-r from-red-500/5 to-purple-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none"></div>
+                <div className="absolute inset-0 bg-gradient-to-r from-[#F2A900]/5 to-[#0072C6]/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none"></div>
               </motion.div>
             );
           })}

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -32,7 +32,7 @@ const Skills: React.FC = () => {
           className="text-center mb-16"
         >
           <h2 className="text-4xl sm:text-5xl font-bold mb-4">
-            <span className="bg-gradient-to-r from-blue-400 via-purple-400 to-red-400 bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent">
               Habilidades y Experiencia
             </span>
           </h2>
@@ -42,7 +42,7 @@ const Skills: React.FC = () => {
         </motion.div>
 
         {/* Skills by Category */}
-        <div className="space-y-12">
+        <div className="space-y-8">
           {categories.map((category, categoryIndex) => {
             const categorySkills = getSkillsByCategory(category);
             
@@ -57,11 +57,11 @@ const Skills: React.FC = () => {
                 {/* Category Title */}
                 <div className="mb-8">
                   <h3 className="text-2xl font-bold text-white mb-2">{category}</h3>
-                  <div className="w-20 h-1 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full"></div>
+                  <div className="w-20 h-1 bg-gradient-to-r from-[#F2A900] to-[#0072C6] rounded-full"></div>
                 </div>
 
                 {/* Skills Grid */}
-                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 place-items-center">
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2 place-items-center">
                   {categorySkills.map((skill, skillIndex) => {
                     const IconComponent = getIconComponent(skill.icon);
 
@@ -74,13 +74,13 @@ const Skills: React.FC = () => {
                           duration: 0.4,
                           delay: categoryIndex * 0.1 + skillIndex * 0.05
                         }}
-                        className="skill-card group relative flex flex-col items-center justify-center gap-3 bg-gradient-to-br from-gray-900/50 to-gray-800/50 border border-gray-700/50 rounded-xl p-6 h-32 backdrop-blur-sm hover:border-blue-500/30 transition-all duration-300"
+                        className="skill-card group relative flex flex-col items-center justify-center gap-3 bg-gradient-to-br from-gray-900/50 to-gray-800/50 border border-gray-700/50 rounded-xl p-6 h-32 backdrop-blur-sm hover:border-[#0072C6]/30 transition-all duration-300"
                       >
-                        <div className="p-3 bg-gradient-to-r from-blue-500/20 to-purple-500/20 rounded-lg">
-                          <IconComponent className="text-blue-400 group-hover:text-white transition-colors" size={28} />
+                        <div className="p-3 bg-gradient-to-r from-[#F2A900]/20 to-[#0072C6]/20 rounded-lg">
+                          <IconComponent className="text-[#0072C6] group-hover:text-white transition-colors" size={28} />
                         </div>
 
-                        <h4 className="text-white font-semibold text-sm text-center group-hover:text-blue-400 transition-colors">
+                        <h4 className="text-white font-semibold text-sm text-center group-hover:text-[#F2A900] transition-colors">
                           {skill.name}
                         </h4>
 
@@ -103,25 +103,25 @@ const Skills: React.FC = () => {
         >
           <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
             <div className="text-center">
-              <div className="text-3xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent mb-2">
+              <div className="text-3xl font-bold bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent mb-2">
                 20+
               </div>
               <div className="text-gray-400 text-sm">Tecnologías</div>
             </div>
             <div className="text-center">
-              <div className="text-3xl font-bold bg-gradient-to-r from-purple-400 to-red-400 bg-clip-text text-transparent mb-2">
+              <div className="text-3xl font-bold bg-gradient-to-r from-[#0072C6] to-[#F2A900] bg-clip-text text-transparent mb-2">
                 5+
               </div>
               <div className="text-gray-400 text-sm">Años de Experiencia</div>
             </div>
             <div className="text-center">
-              <div className="text-3xl font-bold bg-gradient-to-r from-red-400 to-blue-400 bg-clip-text text-transparent mb-2">
+              <div className="text-3xl font-bold bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent mb-2">
                 6
               </div>
               <div className="text-gray-400 text-sm">Categorías de Habilidades</div>
             </div>
             <div className="text-center">
-              <div className="text-3xl font-bold bg-gradient-to-r from-blue-400 to-red-400 bg-clip-text text-transparent mb-2">
+              <div className="text-3xl font-bold bg-gradient-to-r from-[#0072C6] to-[#F2A900] bg-clip-text text-transparent mb-2">
                 90%
               </div>
               <div className="text-gray-400 text-sm">Promedio de Dominio</div>


### PR DESCRIPTION
## Summary
- unify Experience and Skills into one section
- apply golden and blue color scheme throughout components
- adjust skills grid spacing
- update navigation to remove separate skills section

## Testing
- `npm run lint` *(fails: Cannot find package)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ee8b86dd08324a563ef7412a5be54