### PR TITLE
Improve performance and enable sourcemaps

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,12 @@
     <meta property="og:description" content="Portafolio centrado en soluciones tecnológicas, creatividad aplicada y visión estratégica para potenciar procesos e innovación en empresas." />
     <meta property="og:url" content="https://sjaquer.is-a.dev/" />
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" onload="this.rel='stylesheet'">
+    <noscript>
+      <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    </noscript>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -36,7 +36,7 @@ const Gallery: React.FC = () => {
               className={`overflow-hidden rounded-xl relative ${index === 0 ? 'md:col-span-2 md:row-span-2' : ''}`}
             >
               {item.type === 'image' ? (
-                <img src={item.src} alt={item.alt} className="w-full h-full object-cover" />
+                <img loading="lazy" src={item.src} alt={item.alt} className="w-full h-full object-cover" />
               ) : (
                 <video src={item.src} className="w-full h-full object-cover" autoPlay loop muted />
               )}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -199,6 +199,7 @@ const Hero: React.FC = () => {
                 <div className="w-full h-full rounded-full bg-gradient-to-br from-[#F2A900] via-[#0072C6] to-[#F2A900] p-1">
                   <div className="w-full h-full rounded-full bg-gray-900 flex items-center justify-center overflow-hidden">
                     <img
+                      loading="lazy"
                       src={profileImg}
                       alt="Sebastián Jaque"
                       className="w-full h-full object-cover"

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -94,6 +94,7 @@ const Portfolio: React.FC = () => {
                 {/* Project Image */}
                 <div className="relative h-48 overflow-hidden">
                   <img
+                    loading="lazy"
                     src={project.image}
                     alt={project.title}
                     className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  build: {
+    sourcemap: true,
+  },
 });


### PR DESCRIPTION
## Summary
- add `<link rel="preload">` for Google Font
- lazy load gallery, portfolio and hero images
- enable sourcemap generation in vite config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687f08ad03ec832497d320704909766a