### PR TITLE
Add color-coded habilidades grid

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import Header from './components/Header';
 import Hero from './components/Hero';
 import Experience from './components/Experience';
+import Skills from './components/Skills';
 import Education from './components/Education';
 import Portfolio from './components/Portfolio';
 import Gallery from './components/Gallery';
@@ -14,7 +15,7 @@ function App() {
 
   useEffect(() => {
     const handleScroll = () => {
-      const sections = ['home', 'experience', 'education', 'portfolio', 'gallery', 'contact'];
+      const sections = ['home', 'experience', 'skills', 'education', 'portfolio', 'gallery', 'contact'];
       const scrollPosition = window.scrollY + 100;
 
       for (const section of sections) {
@@ -63,6 +64,7 @@ function App() {
         <main>
           <Hero />
           <Experience />
+          <Skills />
           <Education />
           <Portfolio />
           <Gallery />

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { MapPin, Calendar, ExternalLink } from 'lucide-react';
-import * as Icons from 'lucide-react';
-import { experiences, skills } from '../data/portfolio';
+import { experiences } from '../data/portfolio';
 
 const Experience: React.FC = () => {
   const [ref, inView] = useInView({
@@ -11,15 +10,8 @@ const Experience: React.FC = () => {
     triggerOnce: true
   });
 
-  const categories = [...new Set(skills.map(skill => skill.category))];
-  const averageProficiency = Math.round(
-    skills.reduce((sum, s) => sum + s.proficiency, 0) / skills.length
-  );
-
-  const getIconComponent = (iconName: string) => {
-    const IconComponent = (Icons as any)[iconName];
-    return IconComponent || Icons.Code;
-  };
+  // Experience section focuses on career history. Skill details are handled in
+  // the dedicated Skills section.
 
   return (
     <section id="experience" className="py-20 px-4 sm:px-6 lg:px-8">
@@ -136,75 +128,6 @@ const Experience: React.FC = () => {
           ))}
         </motion.div>
 
-        {/* Lenguajes y Programas */}
-        <div className="mt-20">
-          <motion.h3
-            initial={{ opacity: 0, y: 30 }}
-            animate={inView ? { opacity: 1, y: 0 } : {}}
-            transition={{ duration: 0.6 }}
-            className="text-2xl font-bold text-white mb-8 text-center"
-          >
-            Lenguajes y Programas
-          </motion.h3>
-
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-            {skills.map((skill, index) => {
-              const IconComponent = getIconComponent(skill.icon);
-
-              return (
-                <motion.div
-                  key={skill.name}
-                  initial={{ opacity: 0, scale: 0.8 }}
-                  animate={inView ? { opacity: 1, scale: 1 } : {}}
-                  transition={{ duration: 0.4, delay: index * 0.05 }}
-                  className="relative flex flex-col items-center justify-center gap-3 bg-gradient-to-br from-white/10 to-white/5 border border-white/20 rounded-2xl p-6 h-32 backdrop-blur-md"
-                >
-                  <div className="p-3 bg-gradient-to-r from-[#F2A900]/30 to-[#0072C6]/30 rounded-lg">
-                    <IconComponent className="text-[#0072C6]" size={28} />
-                  </div>
-
-                  <h4 className="text-white font-semibold text-sm text-center">
-                    {skill.name}
-                  </h4>
-                </motion.div>
-              );
-            })}
-          </div>
-        </div>
-
-        <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          animate={inView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.6, delay: 0.8 }}
-          className="mt-16 text-center"
-        >
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
-            <div className="text-center">
-              <div className="text-3xl font-bold bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent mb-2">
-                {skills.length}
-              </div>
-              <div className="text-gray-400 text-sm">Tecnologías</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold bg-gradient-to-r from-[#0072C6] to-[#F2A900] bg-clip-text text-transparent mb-2">
-                5+
-              </div>
-              <div className="text-gray-400 text-sm">Años de Experiencia</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent mb-2">
-                {categories.length}
-              </div>
-              <div className="text-gray-400 text-sm">Categorías de Habilidades</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold bg-gradient-to-r from-[#0072C6] to-[#F2A900] bg-clip-text text-transparent mb-2">
-                {averageProficiency}%
-              </div>
-              <div className="text-gray-400 text-sm">Promedio de Dominio</div>
-            </div>
-          </div>
-        </motion.div>
       </div>
     </section>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,6 +13,7 @@ const Header: React.FC<HeaderProps> = ({ activeSection, setActiveSection }) => {
   const sections = [
     { id: 'home', label: 'Inicio' },
     { id: 'experience', label: 'Experiencia' },
+    { id: 'skills', label: 'Habilidades' },
     { id: 'education', label: 'Educación' },
     { id: 'portfolio', label: 'Portafolio' },
     { id: 'gallery', label: 'Galería' },

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -2,24 +2,47 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import * as Icons from 'lucide-react';
-import { skills } from '../data/portfolio';
+import { skills as skillsData } from '../data/portfolio';
+
+const colorMap: Record<string, string> = {
+  JavaScript: '#f7df1e',
+  TypeScript: '#3178c6',
+  Python: '#3776AB',
+  Java: '#b07219',
+  React: '#61dafb',
+  'Vue.js': '#4FC08D',
+  'Next.js': '#000000',
+  'Tailwind CSS': '#38B2AC',
+  'Node.js': '#43853d',
+  'Express.js': '#787878',
+  Django: '#092E20',
+  GraphQL: '#E10098',
+  'Unreal Engine': '#0E1128',
+  'AutoDesk Maya': '#34A0C4',
+  'Danvinci Resolve': '#FF2A00',
+  Photoshop: '#31A8FF',
+  AWS: '#FF9900',
+  Docker: '#0db7ed',
+  Git: '#f1502f',
+  MongoDB: '#47A248',
+  'Excel Avanzado': '#217346',
+  'Gestión Documental': '#6C757D',
+  Planificación: '#3F51B5'
+};
 
 const Skills: React.FC = () => {
-  const [ref, inView] = useInView({
-    threshold: 0.1,
-    triggerOnce: true
-  });
+  const [ref, inView] = useInView({ threshold: 0.1, triggerOnce: true });
 
-  const categories = [...new Set(skills.map(skill => skill.category))];
-  const averageProficiency = Math.round(
-    skills.reduce((sum, s) => sum + s.proficiency, 0) / skills.length
+  const sortedSkills = [...skillsData].sort(
+    (a, b) => b.proficiency - a.proficiency
   );
-
 
   const getIconComponent = (iconName: string) => {
     const IconComponent = (Icons as any)[iconName];
     return IconComponent || Icons.Code;
   };
+
+  const isLarge = (proficiency: number) => proficiency >= 85;
 
   return (
     <section id="skills" className="py-20 px-4 sm:px-6 lg:px-8 bg-gray-900/30">
@@ -33,76 +56,38 @@ const Skills: React.FC = () => {
         >
           <h2 className="text-4xl sm:text-5xl font-bold mb-4">
             <span className="bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent">
-              Lenguajes y Programas
+              Habilidades
             </span>
           </h2>
-          <p className="text-gray-400 text-lg max-w-2xl mx-auto">
-            Un conjunto completo de herramientas que abarca desarrollo full-stack, diseño creativo y tecnologías emergentes
-          </p>
         </motion.div>
 
-        {/* Bento Grid Skills */}
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-          {skills.map((skill, index) => {
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {sortedSkills.map((skill, index) => {
             const IconComponent = getIconComponent(skill.icon);
-
+            const sizeClass = isLarge(skill.proficiency)
+              ? 'col-span-2 aspect-[3/2]'
+              : 'aspect-square';
+            const color = colorMap[skill.name] || '#0072C6';
             return (
               <motion.div
                 key={skill.name}
-                initial={{ opacity: 0, scale: 0.8 }}
+                initial={{ opacity: 0, scale: 0.9 }}
                 animate={inView ? { opacity: 1, scale: 1 } : {}}
                 transition={{ duration: 0.4, delay: index * 0.05 }}
-                className="relative flex flex-col items-center justify-center gap-3 bg-gradient-to-br from-white/10 to-white/5 border border-white/20 rounded-2xl p-6 h-32 backdrop-blur-md"
+                className={`flex flex-col items-center justify-center gap-2 bg-white/10 backdrop-blur-md rounded-2xl shadow-lg hover:scale-[1.03] transition-transform ${sizeClass}`}
               >
-                <div className="p-3 bg-gradient-to-r from-[#F2A900]/30 to-[#0072C6]/30 rounded-lg">
-                  <IconComponent className="text-[#0072C6]" size={28} />
-                </div>
-
-                <h4 className="text-white font-semibold text-sm text-center">
+                <IconComponent style={{ color }} size={32} />
+                <h4 className="text-white font-medium text-sm text-center">
                   {skill.name}
                 </h4>
               </motion.div>
             );
           })}
         </div>
-
-        {/* Skills Summary */}
-        <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          animate={inView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.6, delay: 0.8 }}
-          className="mt-16 text-center"
-        >
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
-            <div className="text-center">
-              <div className="text-3xl font-bold bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent mb-2">
-                {skills.length}
-              </div>
-              <div className="text-gray-400 text-sm">Tecnologías</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold bg-gradient-to-r from-[#0072C6] to-[#F2A900] bg-clip-text text-transparent mb-2">
-                5+
-              </div>
-              <div className="text-gray-400 text-sm">Años de Experiencia</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold bg-gradient-to-r from-[#F2A900] to-[#0072C6] bg-clip-text text-transparent mb-2">
-                {categories.length}
-              </div>
-              <div className="text-gray-400 text-sm">Categorías de Habilidades</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold bg-gradient-to-r from-[#0072C6] to-[#F2A900] bg-clip-text text-transparent mb-2">
-                {averageProficiency}%
-              </div>
-              <div className="text-gray-400 text-sm">Promedio de Dominio</div>
-            </div>
-          </div>
-        </motion.div>
       </div>
     </section>
   );
 };
 
 export default Skills;
+


### PR DESCRIPTION
## Summary
- use dataset from `portfolio.ts` to render skills cards
- sort and size the grid based on proficiency
- colorize icons according to each app and show all labels in Spanish

## Testing
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_687f0f98c494832492d96ba82def3f1b