### PR TITLE
Remove CSS font import

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,8 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
-
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- remove Google Fonts `@import` from `index.css`
- rely on the existing preload tags in `index.html` to load fonts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687f166d578883248aecb5b5280a67e2